### PR TITLE
Enhance KPI backend and charts for chain comparisons

### DIFF
--- a/kpi-backend/server.js
+++ b/kpi-backend/server.js
@@ -10,20 +10,55 @@ app.use(express.json());
 app.get("/api/kpis/stores", async (req, res) => {
   try {
     const { year = 2025 } = req.query;
+    const currentYear = Number(year) || 2025;
+    const previousYear = currentYear - 1;
 
     const query = `
-        SELECT 
-          StoreID,
-          SUM(TotalSales) AS TotalSalesYear,
-          AVG(SalesPerEmployee) AS AvgSalesPerEmployee,
-          AVG(HeadcountGrowthPct) AS AvgGrowth
-        FROM dbo.vw_Employee_KPI_All
-        WHERE Year = @year
-        GROUP BY StoreID
-        ORDER BY TotalSalesYear DESC;
+        WITH CurrentYear AS (
+          SELECT
+            StoreID,
+            SUM(TotalSales) AS TotalSalesYear,
+            AVG(SalesPerEmployee) AS AvgSalesPerEmployee,
+            AVG(HeadcountGrowthPct) AS AvgGrowth
+          FROM dbo.vw_Employee_KPI_All
+          WHERE Year = @year
+          GROUP BY StoreID
+        ),
+        PreviousYear AS (
+          SELECT
+            StoreID,
+            SUM(TotalSales) AS TotalSalesYear
+          FROM dbo.vw_Employee_KPI_All
+          WHERE Year = @previousYear
+          GROUP BY StoreID
+        ),
+        ChainTotals AS (
+          SELECT SUM(TotalSalesYear) AS ChainSales FROM CurrentYear
+        )
+        SELECT
+          c.StoreID,
+          c.TotalSalesYear,
+          c.AvgSalesPerEmployee,
+          c.AvgGrowth,
+          p.TotalSalesYear AS PrevYearSales,
+          CASE
+            WHEN p.TotalSalesYear IS NULL OR p.TotalSalesYear = 0 THEN NULL
+            ELSE ((c.TotalSalesYear - p.TotalSalesYear) / p.TotalSalesYear) * 100
+          END AS SalesYoY,
+          CASE
+            WHEN totals.ChainSales IS NULL OR totals.ChainSales = 0 THEN NULL
+            ELSE (c.TotalSalesYear / totals.ChainSales) * 100
+          END AS SalesContributionPct
+        FROM CurrentYear c
+        LEFT JOIN PreviousYear p ON p.StoreID = c.StoreID
+        CROSS JOIN ChainTotals totals
+        ORDER BY c.TotalSalesYear DESC;
       `;
 
-    const data = await queryDatabase(query, { year });
+    const data = await queryDatabase(query, {
+      year: currentYear,
+      previousYear,
+    });
     res.json(data);
   } catch (err) {
     console.error(err);
@@ -36,23 +71,76 @@ app.get("/api/kpis/store/:id", async (req, res) => {
   try {
     const { year = 2025 } = req.query;
     const { id } = req.params;
+    const currentYear = Number(year) || 2025;
+    const previousYear = currentYear - 1;
 
     const query = `
-        SELECT 
-          Year,
-          MonthNumber,
-          StoreID,
-          TotalSales,
-          AvgHeadcount,
-          SalesPerEmployee,
-          HeadcountGrowthPct,
-          Turnover
-        FROM dbo.vw_Employee_KPI_All
-        WHERE Year = @year AND StoreID = @storeId
-        ORDER BY MonthNumber;
+        WITH StoreData AS (
+          SELECT
+            Year,
+            MonthNumber,
+            StoreID,
+            TotalSales,
+            AvgHeadcount,
+            SalesPerEmployee,
+            HeadcountGrowthPct,
+            Turnover
+          FROM dbo.vw_Employee_KPI_All
+          WHERE Year = @year AND StoreID = @storeId
+        )
+        SELECT
+          sd.Year,
+          sd.MonthNumber,
+          sd.StoreID,
+          sd.TotalSales,
+          sd.AvgHeadcount,
+          sd.SalesPerEmployee,
+          sd.HeadcountGrowthPct,
+          sd.Turnover,
+          totals.ChainTotalSales,
+          totals.ChainAvgSales,
+          totals.ChainAvgSalesPerEmployee,
+          totals.ChainAvgHeadcount,
+          totals.ChainAvgGrowth,
+          totals.ChainAvgTurnover,
+          totals.ChainStoreCount,
+          prev.PrevYearTotalSales,
+          prev.PrevYearSalesPerEmployee,
+          prev.PrevYearHeadcountGrowth,
+          prev.PrevYearTurnover
+        FROM StoreData sd
+        CROSS APPLY (
+          SELECT
+            SUM(v.TotalSales) AS ChainTotalSales,
+            CASE WHEN COUNT(*) = 0 THEN NULL ELSE SUM(v.TotalSales) / COUNT(*) END AS ChainAvgSales,
+            AVG(v.SalesPerEmployee) AS ChainAvgSalesPerEmployee,
+            AVG(v.AvgHeadcount) AS ChainAvgHeadcount,
+            AVG(v.HeadcountGrowthPct) AS ChainAvgGrowth,
+            AVG(v.Turnover) AS ChainAvgTurnover,
+            COUNT(*) AS ChainStoreCount
+          FROM dbo.vw_Employee_KPI_All v
+          WHERE v.Year = sd.Year AND v.MonthNumber = sd.MonthNumber
+        ) totals
+        OUTER APPLY (
+          SELECT TOP 1
+            v.TotalSales AS PrevYearTotalSales,
+            v.SalesPerEmployee AS PrevYearSalesPerEmployee,
+            v.HeadcountGrowthPct AS PrevYearHeadcountGrowth,
+            v.Turnover AS PrevYearTurnover
+          FROM dbo.vw_Employee_KPI_All v
+          WHERE v.Year = @previousYear
+            AND v.MonthNumber = sd.MonthNumber
+            AND v.StoreID = sd.StoreID
+          ORDER BY v.Year DESC
+        ) prev
+        ORDER BY sd.MonthNumber;
       `;
 
-    const data = await queryDatabase(query, { year, storeId: id });
+    const data = await queryDatabase(query, {
+      year: currentYear,
+      storeId: id,
+      previousYear,
+    });
     res.json(data);
   } catch (err) {
     console.error(err);

--- a/src/components/Charts/EfficiencyTrend.jsx
+++ b/src/components/Charts/EfficiencyTrend.jsx
@@ -18,6 +18,20 @@ const monthFormatter = (value) =>
 export default function EfficiencyTrend({ data }) {
   if (!data || data.length === 0) return null;
 
+  const parseValue = (value) => {
+    if (value == null || value === "") return null;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
+  const enhancedData = data.map((item) => ({
+    ...item,
+    SalesPerEmployee: parseValue(item.SalesPerEmployee),
+    ChainAvgSalesPerEmployee: parseValue(item.ChainAvgSalesPerEmployee),
+    AvgHeadcount: parseValue(item.AvgHeadcount),
+    ChainAvgHeadcount: parseValue(item.ChainAvgHeadcount),
+  }));
+
   return (
     <Card sx={{ borderRadius: 4, boxShadow: "0 18px 40px rgba(15,23,42,0.08)" }}>
       <CardContent>
@@ -39,7 +53,7 @@ export default function EfficiencyTrend({ data }) {
           <Chip label="Higher is better" color="success" variant="outlined" />
         </Stack>
         <ResponsiveContainer width="100%" height={360}>
-          <ComposedChart data={data}>
+          <ComposedChart data={enhancedData}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
             <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
             <YAxis
@@ -59,8 +73,14 @@ export default function EfficiencyTrend({ data }) {
                 if (name === "SalesPerEmployee") {
                   return [`$${Number(value).toFixed(0)}`, "Sales per Employee"];
                 }
+                if (name === "ChainAvgSalesPerEmployee") {
+                  return [`$${Number(value).toFixed(0)}`, "Chain Avg Sales per Employee"];
+                }
                 if (name === "AvgHeadcount") {
                   return [Number(value).toFixed(0), "Avg Headcount"];
+                }
+                if (name === "ChainAvgHeadcount") {
+                  return [Number(value).toFixed(0), "Chain Avg Headcount"];
                 }
                 return [value, name];
               }}
@@ -70,17 +90,39 @@ export default function EfficiencyTrend({ data }) {
               yAxisId="left"
               type="monotone"
               dataKey="SalesPerEmployee"
+              name="Store Sales per Employee"
               stroke="#0ea5e9"
               fill="#0ea5e933"
               strokeWidth={3}
               activeDot={{ r: 6 }}
             />
+            <Line
+              yAxisId="left"
+              type="monotone"
+              dataKey="ChainAvgSalesPerEmployee"
+              name="Chain Avg Sales per Employee"
+              stroke="#38bdf8"
+              strokeWidth={3}
+              strokeDasharray="5 5"
+              dot={false}
+            />
             <Bar
               yAxisId="right"
               dataKey="AvgHeadcount"
+              name="Store Avg Headcount"
               fill="#22c55e"
               radius={[12, 12, 0, 0]}
               barSize={28}
+            />
+            <Line
+              yAxisId="right"
+              type="monotone"
+              dataKey="ChainAvgHeadcount"
+              name="Chain Avg Headcount"
+              stroke="#4ade80"
+              strokeWidth={3}
+              strokeDasharray="3 6"
+              dot={false}
             />
           </ComposedChart>
         </ResponsiveContainer>

--- a/src/components/Charts/PeopleHealth.jsx
+++ b/src/components/Charts/PeopleHealth.jsx
@@ -17,6 +17,20 @@ const monthFormatter = (value) =>
 export default function PeopleHealth({ data }) {
   if (!data || data.length === 0) return null;
 
+  const parseValue = (value) => {
+    if (value == null || value === "") return null;
+    const numeric = Number.parseFloat(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
+  const normalizedData = data.map((item) => ({
+    ...item,
+    HeadcountGrowthPct: parseValue(item.HeadcountGrowthPct),
+    Turnover: parseValue(item.Turnover),
+    ChainAvgGrowth: parseValue(item.ChainAvgGrowth),
+    ChainAvgTurnover: parseValue(item.ChainAvgTurnover),
+  }));
+
   return (
     <Card sx={{ borderRadius: 4, boxShadow: "0 18px 40px rgba(15,23,42,0.08)" }}>
       <CardContent>
@@ -29,7 +43,7 @@ export default function PeopleHealth({ data }) {
           </Typography>
         </Stack>
         <ResponsiveContainer width="100%" height={320}>
-          <LineChart data={data}>
+          <LineChart data={normalizedData}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
             <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
             <YAxis
@@ -45,24 +59,60 @@ export default function PeopleHealth({ data }) {
             />
             <Tooltip
               labelFormatter={(label) => monthFormatter(label)}
-              formatter={(value, name) => [`${Number(value).toFixed(1)}%`, name === "HeadcountGrowthPct" ? "Headcount Growth" : "Turnover"]}
+              formatter={(value, name) => {
+                const formattedValue = `${Number(value).toFixed(1)}%`;
+                switch (name) {
+                  case "HeadcountGrowthPct":
+                    return [formattedValue, "Headcount Growth"];
+                  case "ChainAvgGrowth":
+                    return [formattedValue, "Chain Avg Headcount Growth"];
+                  case "Turnover":
+                    return [formattedValue, "Turnover"];
+                  case "ChainAvgTurnover":
+                    return [formattedValue, "Chain Avg Turnover"];
+                  default:
+                    return [formattedValue, name];
+                }
+              }}
             />
             <Legend />
             <Line
               yAxisId="left"
               type="monotone"
               dataKey="HeadcountGrowthPct"
+              name="Store Headcount Growth"
               stroke="#8b5cf6"
+              strokeWidth={3}
+              dot={{ r: 3 }}
+            />
+            <Line
+              yAxisId="left"
+              type="monotone"
+              dataKey="ChainAvgGrowth"
+              name="Chain Avg Headcount Growth"
+              stroke="#c084fc"
+              strokeWidth={3}
+              strokeDasharray="5 5"
+              dot={false}
+            />
+            <Line
+              yAxisId="right"
+              type="monotone"
+              dataKey="Turnover"
+              name="Store Turnover"
+              stroke="#f97316"
               strokeWidth={3}
               dot={{ r: 3 }}
             />
             <Line
               yAxisId="right"
               type="monotone"
-              dataKey="Turnover"
-              stroke="#f97316"
+              dataKey="ChainAvgTurnover"
+              name="Chain Avg Turnover"
+              stroke="#fbbf24"
               strokeWidth={3}
-              dot={{ r: 3 }}
+              strokeDasharray="3 6"
+              dot={false}
             />
           </LineChart>
         </ResponsiveContainer>

--- a/src/components/Charts/SalesTrend.jsx
+++ b/src/components/Charts/SalesTrend.jsx
@@ -15,17 +15,48 @@ const monthFormatter = (value) =>
   new Date(0, Number(value) - 1).toLocaleString("default", { month: "short" });
 
 const currencyFormatter = (value) =>
-  value?.toLocaleString(undefined, { style: "currency", currency: "USD", maximumFractionDigits: 0 });
+  value?.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
 
 export default function SalesTrend({ data, storeId }) {
   if (!data || data.length === 0) return null;
 
+  const parseValue = (value) => {
+    if (value == null || value === "") return null;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  };
+
   const year = data[0]?.Year;
+  const enrichedData = data.map((item) => {
+    const chainAvgSales =
+      item.ChainAvgSales ??
+      (item.ChainTotalSales && item.ChainStoreCount
+        ? item.ChainTotalSales / item.ChainStoreCount
+        : null);
+
+    return {
+      ...item,
+      TotalSales: parseValue(item.TotalSales),
+      ChainAvgSales: parseValue(chainAvgSales),
+      SalesPerEmployee: parseValue(item.SalesPerEmployee),
+      ChainAvgSalesPerEmployee: parseValue(item.ChainAvgSalesPerEmployee),
+    };
+  });
 
   return (
     <Card sx={{ borderRadius: 4, boxShadow: "0 18px 40px rgba(15,23,42,0.1)" }}>
       <CardContent>
-        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} justifyContent="space-between" alignItems="flex-start" mb={3}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          justifyContent="space-between"
+          alignItems="flex-start"
+          mb={3}
+        >
           <div>
             <Typography variant="h6" gutterBottom sx={{ fontWeight: 700 }}>
               Revenue & Efficiency Trend
@@ -34,10 +65,10 @@ export default function SalesTrend({ data, storeId }) {
               Tracking monthly performance for store {storeId} in {year}.
             </Typography>
           </div>
-          <Chip label="Sales vs. Sales per Employee" color="primary" variant="outlined" />
+          <Chip label="Store vs. chain benchmarks" color="primary" variant="outlined" />
         </Stack>
         <ResponsiveContainer width="100%" height={380}>
-          <LineChart data={data}>
+          <LineChart data={enrichedData}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
             <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
             <YAxis
@@ -56,10 +87,17 @@ export default function SalesTrend({ data, storeId }) {
             <Tooltip
               formatter={(val, name) => {
                 if (name === "TotalSales") return [currencyFormatter(val), "Total Sales"];
+                if (name === "ChainAvgSales")
+                  return [currencyFormatter(val), "Chain Avg Sales"];
                 if (name === "SalesPerEmployee")
                   return [
                     `$${Number(val).toFixed(0)}`,
                     "Sales per Employee",
+                  ];
+                if (name === "ChainAvgSalesPerEmployee")
+                  return [
+                    `$${Number(val).toFixed(0)}`,
+                    "Chain Avg Sales per Employee",
                   ];
                 return [val, name];
               }}
@@ -70,7 +108,28 @@ export default function SalesTrend({ data, storeId }) {
               yAxisId="left"
               type="monotone"
               dataKey="TotalSales"
+              name="Store Total Sales"
               stroke="#2563eb"
+              strokeWidth={3}
+              dot={{ r: 3 }}
+              activeDot={{ r: 6 }}
+            />
+            <Line
+              yAxisId="left"
+              type="monotone"
+              dataKey="ChainAvgSales"
+              name="Chain Avg Sales"
+              stroke="#60a5fa"
+              strokeWidth={3}
+              strokeDasharray="6 6"
+              dot={false}
+            />
+            <Line
+              yAxisId="right"
+              type="monotone"
+              dataKey="SalesPerEmployee"
+              name="Store Sales per Employee"
+              stroke="#f59e0b"
               strokeWidth={3}
               dot={{ r: 3 }}
               activeDot={{ r: 6 }}
@@ -78,11 +137,12 @@ export default function SalesTrend({ data, storeId }) {
             <Line
               yAxisId="right"
               type="monotone"
-              dataKey="SalesPerEmployee"
-              stroke="#f59e0b"
+              dataKey="ChainAvgSalesPerEmployee"
+              name="Chain Avg Sales per Employee"
+              stroke="#facc15"
               strokeWidth={3}
-              dot={{ r: 3 }}
-              activeDot={{ r: 6 }}
+              strokeDasharray="4 4"
+              dot={false}
             />
           </LineChart>
         </ResponsiveContainer>

--- a/src/components/KpiCard.jsx
+++ b/src/components/KpiCard.jsx
@@ -1,11 +1,26 @@
 import React from "react";
-import { Card, CardContent, Typography, Box, Chip } from "@mui/material";
+import { Card, CardContent, Typography, Box, Chip, Stack } from "@mui/material";
 import TrendingUpIcon from "@mui/icons-material/TrendingUp";
 import TrendingDownIcon from "@mui/icons-material/TrendingDown";
 
-export default function KpiCard({ title, value, change }) {
-  const showChange = typeof change === "number" && !Number.isNaN(change);
-  const positive = (showChange && change >= 0) || false;
+export default function KpiCard({ title, value, change, secondary = [] }) {
+  const showChange = Number.isFinite(change);
+  const positive = showChange && change >= 0;
+
+  const renderSecondaryChip = (chip) => {
+    if (!chip || !Number.isFinite(chip.value)) return null;
+    const isPositive = chip.value >= 0;
+    return (
+      <Chip
+        key={chip.label}
+        size="small"
+        variant="outlined"
+        color={isPositive ? "success" : "error"}
+        label={`${isPositive ? "+" : ""}${chip.value.toFixed(1)}% ${chip.label}`}
+        sx={{ fontWeight: 600 }}
+      />
+    );
+  };
   return (
     <Card
       sx={{
@@ -23,28 +38,38 @@ export default function KpiCard({ title, value, change }) {
         <Typography variant="h4" sx={{ fontWeight: 700, mt: 1 }}>
           {value}
         </Typography>
-        {showChange ? (
-          <Box display="flex" alignItems="center" mt={2} gap={1}>
-            {positive ? (
-              <TrendingUpIcon sx={{ color: "#16a34a" }} />
-            ) : (
-              <TrendingDownIcon sx={{ color: "#dc2626" }} />
-            )}
+        <Stack
+          direction="row"
+          flexWrap="wrap"
+          spacing={1}
+          useFlexGap
+          sx={{ mt: 2 }}
+          alignItems="center"
+        >
+          {showChange ? (
+            <Box display="flex" alignItems="center" gap={1}>
+              {positive ? (
+                <TrendingUpIcon sx={{ color: "#16a34a" }} />
+              ) : (
+                <TrendingDownIcon sx={{ color: "#dc2626" }} />
+              )}
+              <Chip
+                size="small"
+                color={positive ? "success" : "error"}
+                label={`${positive ? "+" : ""}${change.toFixed(1)}% vs prev.`}
+                sx={{ fontWeight: 600 }}
+              />
+            </Box>
+          ) : (
             <Chip
               size="small"
-              color={positive ? "success" : "error"}
-              label={`${positive ? "+" : ""}${change.toFixed(1)}% vs prev.`}
-              sx={{ fontWeight: 600 }}
+              label="No previous month"
+              sx={{ fontWeight: 600, color: "text.secondary" }}
+              variant="outlined"
             />
-          </Box>
-        ) : (
-          <Chip
-            size="small"
-            label="No previous month"
-            sx={{ mt: 2, fontWeight: 600, color: "text.secondary" }}
-            variant="outlined"
-          />
-        )}
+          )}
+          {secondary.map((chip) => renderSecondaryChip(chip))}
+        </Stack>
       </CardContent>
     </Card>
   );

--- a/src/components/KpiOverview.jsx
+++ b/src/components/KpiOverview.jsx
@@ -2,18 +2,36 @@ import React from "react";
 import { Grid, Typography, Box } from "@mui/material";
 import KpiCard from "./KpiCard";
 
-// Helper: calculate change between two numbers
+const formatCurrency = (value) =>
+  value?.toLocaleString(undefined, {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 0,
+  });
+
+const toNumber = (value) => {
+  if (value == null) return null;
+  const numeric =
+    typeof value === "string" ? Number.parseFloat(value.replace("%", "")) : Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+};
+
 function calculateChange(current, previous) {
+  const currentValue = toNumber(current);
+  const previousValue = toNumber(previous);
+
   if (
-    current == null ||
-    previous == null ||
-    previous === 0 ||
-    isNaN(current) ||
-    isNaN(previous)
+    currentValue == null ||
+    previousValue == null ||
+    previousValue === 0 ||
+    Number.isNaN(currentValue) ||
+    Number.isNaN(previousValue)
   ) {
     return null;
   }
-  return (((current - previous) / Math.abs(previous)) * 100).toFixed(1);
+
+  const percentage = ((currentValue - previousValue) / Math.abs(previousValue)) * 100;
+  return Number.isFinite(percentage) ? Number(percentage.toFixed(1)) : null;
 }
 
 export default function KpiOverview({ data }) {
@@ -31,39 +49,74 @@ export default function KpiOverview({ data }) {
   const latest = data[data.length - 1];
   const previous = data.length > 1 ? data[data.length - 2] : null;
 
-  // Parse values safely
-  const totalSales = latest.TotalSales ?? null;
-  const prevSales = previous ? previous.TotalSales : null;
+  const totalSales = toNumber(latest.TotalSales);
+  const prevSales = previous ? toNumber(previous.TotalSales) : null;
+  const chainAvgSales = toNumber(latest.ChainAvgSales);
+  const prevYearSales = toNumber(latest.PrevYearTotalSales);
 
-  const avgHeadcount = latest.AvgHeadcount ?? null;
-  const prevHeadcount = previous ? previous.AvgHeadcount : null;
+  const avgHeadcount = toNumber(latest.AvgHeadcount);
+  const prevHeadcount = previous ? toNumber(previous.AvgHeadcount) : null;
+  const chainAvgHeadcount = toNumber(latest.ChainAvgHeadcount);
 
-  const salesPerEmp = latest.SalesPerEmployee ?? null;
-  const prevSalesPerEmp = previous ? previous.SalesPerEmployee : null;
+  const salesPerEmp = toNumber(latest.SalesPerEmployee);
+  const prevSalesPerEmp = previous ? toNumber(previous.SalesPerEmployee) : null;
+  const chainAvgSalesPerEmp = toNumber(latest.ChainAvgSalesPerEmployee);
+  const prevYearSalesPerEmp = toNumber(latest.PrevYearSalesPerEmployee);
 
-  const turnover = parseFloat(latest.Turnover); // handles "9.09%" → 9.09
-  const prevTurnover = previous ? parseFloat(previous.Turnover) : null;
+  const turnover = toNumber(latest.Turnover);
+  const prevTurnover = previous ? toNumber(previous.Turnover) : null;
+  const chainAvgTurnover = toNumber(latest.ChainAvgTurnover);
+  const prevYearTurnover = toNumber(latest.PrevYearTurnover);
 
   const cards = [
     {
       title: "Total Sales",
-      value: totalSales != null ? `$${totalSales.toLocaleString()}` : "-",
+      value: totalSales != null ? formatCurrency(totalSales) : "-",
       change: calculateChange(totalSales, prevSales),
+      secondary: [
+        prevYearSales != null
+          ? { label: "vs last year", value: calculateChange(totalSales, prevYearSales) }
+          : null,
+        chainAvgSales != null
+          ? { label: "vs chain avg", value: calculateChange(totalSales, chainAvgSales) }
+          : null,
+      ].filter(Boolean),
     },
     {
       title: "Avg Headcount",
       value: avgHeadcount != null ? avgHeadcount.toFixed(1) : "-",
       change: calculateChange(avgHeadcount, prevHeadcount),
+      secondary: [
+        chainAvgHeadcount != null
+          ? { label: "vs chain avg", value: calculateChange(avgHeadcount, chainAvgHeadcount) }
+          : null,
+      ].filter(Boolean),
     },
     {
       title: "Sales per Employee",
       value: salesPerEmp != null ? `$${salesPerEmp.toFixed(2)}` : "-",
       change: calculateChange(salesPerEmp, prevSalesPerEmp),
+      secondary: [
+        prevYearSalesPerEmp != null
+          ? { label: "vs last year", value: calculateChange(salesPerEmp, prevYearSalesPerEmp) }
+          : null,
+        chainAvgSalesPerEmp != null
+          ? { label: "vs chain avg", value: calculateChange(salesPerEmp, chainAvgSalesPerEmp) }
+          : null,
+      ].filter(Boolean),
     },
     {
       title: "Turnover",
-      value: !isNaN(turnover) ? turnover.toFixed(1) + "%" : "-",
+      value: turnover != null ? turnover.toFixed(1) + "%" : "-",
       change: calculateChange(turnover, prevTurnover),
+      secondary: [
+        prevYearTurnover != null
+          ? { label: "vs last year", value: calculateChange(turnover, prevYearTurnover) }
+          : null,
+        chainAvgTurnover != null
+          ? { label: "vs chain avg", value: calculateChange(turnover, chainAvgTurnover) }
+          : null,
+      ].filter(Boolean),
     },
   ];
 


### PR DESCRIPTION
## Summary
- extend the KPI store and store-detail endpoints to calculate year-over-year deltas and chain benchmarks for each store
- normalize API responses on the client and surface contribution, growth, and chain-average context in the filters and overview cards
- overlay chain average series across the revenue, efficiency, and people health charts for richer comparisons

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3a3e370648324a7d7b61b2ad6a6b6