### PR TITLE
Simplify KPI dashboard layout for sparse data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -18,7 +18,6 @@ import {
   Box,
   Skeleton,
   Paper,
-  Chip,
 } from "@mui/material";
 import { alpha } from "@mui/material/styles";
 
@@ -159,265 +158,178 @@ export default function App() {
   );
   const storeHighlights = useMemo(() => {
     if (!selectedStoreRecord) return [];
-    const yoy =
-      selectedStoreRecord.SalesYoY != null && Number.isFinite(Number(selectedStoreRecord.SalesYoY))
-        ? Number(selectedStoreRecord.SalesYoY)
-        : null;
 
-    return [
-      {
-        label: "Chain Contribution",
-        value:
-          selectedStoreRecord.SalesContributionPct != null &&
-          Number.isFinite(Number(selectedStoreRecord.SalesContributionPct))
-            ? formatAbsolutePercent(selectedStoreRecord.SalesContributionPct)
-            : "—",
-        caption: "of annual revenue",
-      },
-      {
-        label: "Annual Sales",
-        value: formatCurrency(selectedStoreRecord.TotalSalesYear) ?? "—",
-        caption: `Fiscal year ${year}`,
-      },
-      {
-        label: "YoY Growth",
-        value: yoy != null ? `${yoy >= 0 ? "+" : ""}${yoy.toFixed(1)}%` : "—",
-        caption: "vs previous year",
-        valueColor: yoy != null ? (yoy >= 0 ? "success.light" : "error.light") : undefined,
-      },
-      {
-        label: "Sales per Employee",
-        value:
-          selectedStoreRecord.AvgSalesPerEmployee != null &&
-          Number.isFinite(Number(selectedStoreRecord.AvgSalesPerEmployee))
-            ? formatCurrency(selectedStoreRecord.AvgSalesPerEmployee)
-            : "—",
-        caption: "productivity snapshot",
-      },
-    ];
-  }, [selectedStoreRecord, year]);
+    const metrics = [];
+
+    if (
+      selectedStoreRecord.TotalSalesYear != null &&
+      Number.isFinite(Number(selectedStoreRecord.TotalSalesYear))
+    ) {
+      metrics.push({
+        label: "Annual sales",
+        value: formatCurrency(Number(selectedStoreRecord.TotalSalesYear)),
+      });
+    }
+
+    if (
+      selectedStoreRecord.SalesYoY != null &&
+      Number.isFinite(Number(selectedStoreRecord.SalesYoY))
+    ) {
+      const yoy = Number(selectedStoreRecord.SalesYoY);
+      metrics.push({
+        label: "YoY change",
+        value: `${yoy >= 0 ? "+" : ""}${yoy.toFixed(1)}%`,
+        tone: yoy >= 0 ? "success.main" : "error.main",
+      });
+    }
+
+    if (
+      selectedStoreRecord.AvgSalesPerEmployee != null &&
+      Number.isFinite(Number(selectedStoreRecord.AvgSalesPerEmployee))
+    ) {
+      metrics.push({
+        label: "Sales per employee",
+        value: formatCurrency(Number(selectedStoreRecord.AvgSalesPerEmployee)),
+      });
+    }
+
+    if (
+      selectedStoreRecord.SalesContributionPct != null &&
+      Number.isFinite(Number(selectedStoreRecord.SalesContributionPct))
+    ) {
+      metrics.push({
+        label: "Chain contribution",
+        value: formatAbsolutePercent(Number(selectedStoreRecord.SalesContributionPct)),
+      });
+    }
+
+    return metrics;
+  }, [selectedStoreRecord]);
 
   return (
     <Layout darkMode={darkMode} onToggleDarkMode={() => setDarkMode((prev) => !prev)}>
       <Stack spacing={5}>
-        <Box
-          sx={(theme) => ({
-            position: "relative",
-            overflow: "hidden",
-            borderRadius: 4,
-            px: { xs: 3, md: 6 },
-            py: { xs: 5, md: 6 },
-            color:
-              theme.palette.mode === "dark"
-                ? theme.palette.primary.contrastText
-                : theme.palette.text.primary,
-            background:
-              theme.palette.mode === "dark"
-                ? `radial-gradient(circle at 15% 0%, ${alpha(theme.palette.primary.main, 0.6)} 0%, transparent 55%), linear-gradient(140deg, ${alpha(
-                    theme.palette.background.paper,
-                    0.95
-                  )} 0%, ${alpha(theme.palette.background.paper, 0.7)} 55%, ${alpha(
-                    theme.palette.primary.dark,
-                    0.4
-                  )} 100%)`
-                : `radial-gradient(circle at -10% 0%, ${alpha(theme.palette.primary.light, 0.55)} 0%, transparent 60%), linear-gradient(135deg, ${alpha(
-                    theme.palette.primary.main,
-                    0.15
-                  )} 0%, #ffffff 55%, ${alpha(theme.palette.primary.main, 0.08)} 100%)`,
-            boxShadow:
-              theme.palette.mode === "dark"
-                ? "0 32px 90px rgba(15, 23, 42, 0.85)"
-                : "0 24px 60px rgba(37, 99, 235, 0.18)",
-          })}
-        >
-          <Stack spacing={3} sx={{ position: "relative", zIndex: 1 }}>
-            <Chip
-              label="Crowdt Intelligence"
-              color="primary"
-              sx={{
-                alignSelf: "flex-start",
-                fontWeight: 600,
-                letterSpacing: 0.4,
-                textTransform: "uppercase",
-              }}
-            />
-            <Stack spacing={1.5}>
-              <Typography variant="h3" sx={{ fontWeight: 800, lineHeight: 1.1 }}>
-                Store KPI Performance
-              </Typography>
-              <Typography
-                variant="body1"
-                sx={{ maxWidth: 520, color: (theme) => alpha(theme.palette.text.primary, 0.75) }}
-              >
-                Keep every Crowdt location on pace with a single dashboard that merges sales,
-                efficiency, and people signals into one decisive view.
-              </Typography>
-            </Stack>
-            <Stack
-              direction={{ xs: "column", sm: "row" }}
-              spacing={2}
-              useFlexGap
-              flexWrap="wrap"
-            >
-              <Typography variant="body2" sx={{ opacity: 0.8 }}>
-                Updated automatically from live store telemetry
-              </Typography>
-              <Typography variant="body2" sx={{ opacity: 0.8 }}>
-                Highlighting <strong>{YEAR_OPTIONS.length}</strong> fiscal years of history
-              </Typography>
-            </Stack>
-          </Stack>
-        </Box>
-
         <Paper
           elevation={0}
           sx={(theme) => ({
-            borderRadius: 4,
+            borderRadius: 3,
             p: { xs: 3, md: 4 },
-            display: "flex",
-            flexDirection: { xs: "column", md: "row" },
-            gap: { xs: 3, md: 4 },
-            alignItems: { xs: "stretch", md: "center" },
-            border: `1px solid ${alpha(theme.palette.primary.main, theme.palette.mode === "dark" ? 0.35 : 0.18)}`,
-            background:
-              theme.palette.mode === "dark"
-                ? alpha(theme.palette.background.paper, 0.9)
-                : "#ffffff",
-            boxShadow:
-              theme.palette.mode === "dark"
-                ? "0 20px 50px rgba(15, 23, 42, 0.6)"
-                : "0 18px 45px rgba(15, 23, 42, 0.08)",
-            backdropFilter: "blur(16px)",
+            border: `1px solid ${alpha(theme.palette.divider, 0.4)}`,
+            backgroundColor: theme.palette.background.paper,
           })}
         >
-          <Stack
-            direction={{ xs: "column", sm: "row" }}
-            spacing={2}
-            alignItems={{ xs: "stretch", sm: "center" }}
-            sx={{ flexShrink: 0, minWidth: { md: 420 } }}
-          >
-            <FormControl sx={{ minWidth: 160 }} disabled={loadingStores}>
-              <InputLabel>Year</InputLabel>
-              <Select value={year} label="Year" onChange={(event) => setYear(event.target.value)}>
-                {YEAR_OPTIONS.map((option) => (
-                  <MenuItem key={option} value={option}>
-                    {option}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-
-            <FormControl sx={{ minWidth: 220 }} disabled={loadingStores || stores.length === 0}>
-              <InputLabel>Store</InputLabel>
-              <Select
-                value={selectedStore}
-                label="Store"
-                onChange={(event) => setSelectedStore(event.target.value)}
-              >
-                {stores.map((store) => {
-                  const yoy = store.SalesYoY;
-                  const contribution = store.SalesContributionPct;
-                  return (
-                    <MenuItem key={store.StoreID} value={store.StoreID}>
-                      <Stack
-                        direction="row"
-                        justifyContent="space-between"
-                        alignItems="center"
-                        sx={{ width: "100%" }}
-                      >
-                        <Stack spacing={0.5}>
-                          <Typography variant="body1" sx={{ fontWeight: 600 }}>
-                            {store.StoreID}
-                          </Typography>
-                          {contribution != null && (
-                            <Typography variant="caption" color="text.secondary">
-                              {formatAbsolutePercent(contribution)} of chain sales
-                            </Typography>
-                          )}
-                        </Stack>
-                        <Stack spacing={0.5} alignItems="flex-end">
-                          <Typography component="span" variant="body2" color="text.secondary">
-                            {formatCurrency(store.TotalSalesYear)}
-                          </Typography>
-                          {yoy != null && (
-                            <Typography
-                              variant="caption"
-                              sx={{
-                                color: yoy >= 0 ? "success.main" : "error.main",
-                                fontWeight: 600,
-                              }}
-                            >
-                              {`${yoy >= 0 ? "+" : ""}${yoy.toFixed(1)}% vs LY`}
-                            </Typography>
-                          )}
-                        </Stack>
-                      </Stack>
-                    </MenuItem>
-                  );
-                })}
-              </Select>
-            </FormControl>
-          </Stack>
-
-          {selectedStoreRecord && (
-            <Box
-              sx={(theme) => ({
-                flex: 1,
-                borderLeft: {
-                  md: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-                },
-                borderTop: {
-                  xs: `1px solid ${alpha(theme.palette.text.primary, 0.08)}`,
-                  md: "none",
-                },
-                pl: { md: 4 },
-                pt: { xs: 3, md: 0 },
-              })}
+          <Stack spacing={3}>
+            <Stack
+              direction={{ xs: "column", md: "row" }}
+              spacing={3}
+              justifyContent="space-between"
+              alignItems={{ xs: "flex-start", md: "center" }}
             >
-              <Typography variant="subtitle2" color="text.secondary" sx={{ mb: 2 }}>
-                {selectedStoreRecord.StoreID} spotlight
-              </Typography>
+              <Stack spacing={0.5}>
+                <Typography variant="h5" sx={{ fontWeight: 700 }}>
+                  Store KPI snapshot
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {year} · {selectedStoreRecord?.StoreID ?? "Select a store"}
+                </Typography>
+              </Stack>
+              <Stack
+                direction={{ xs: "column", sm: "row" }}
+                spacing={2}
+                sx={{ width: { xs: "100%", sm: "auto" } }}
+              >
+                <FormControl fullWidth size="small" disabled={loadingStores}>
+                  <InputLabel>Year</InputLabel>
+                  <Select value={year} label="Year" onChange={(event) => setYear(event.target.value)}>
+                    {YEAR_OPTIONS.map((option) => (
+                      <MenuItem key={option} value={option}>
+                        {option}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+
+                <FormControl
+                  fullWidth
+                  size="small"
+                  disabled={loadingStores || stores.length === 0}
+                >
+                  <InputLabel>Store</InputLabel>
+                  <Select
+                    value={selectedStore}
+                    label="Store"
+                    onChange={(event) => setSelectedStore(event.target.value)}
+                  >
+                    {stores.map((store) => {
+                      const yoy =
+                        store.SalesYoY != null && Number.isFinite(Number(store.SalesYoY))
+                          ? Number(store.SalesYoY)
+                          : null;
+                      return (
+                        <MenuItem key={store.StoreID} value={store.StoreID}>
+                          <Stack
+                            direction="row"
+                            justifyContent="space-between"
+                            alignItems="center"
+                            sx={{ width: "100%" }}
+                          >
+                            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                              {store.StoreID}
+                            </Typography>
+                            <Stack spacing={0.5} alignItems="flex-end">
+                              {store.TotalSalesYear != null && (
+                                <Typography variant="body2" color="text.secondary">
+                                  {formatCurrency(store.TotalSalesYear)}
+                                </Typography>
+                              )}
+                              {yoy != null && (
+                                <Typography
+                                  variant="caption"
+                                  sx={{ color: yoy >= 0 ? "success.main" : "error.main" }}
+                                >
+                                  {`${yoy >= 0 ? "+" : ""}${yoy.toFixed(1)}%`}
+                                </Typography>
+                              )}
+                            </Stack>
+                          </Stack>
+                        </MenuItem>
+                      );
+                    })}
+                  </Select>
+                </FormControl>
+              </Stack>
+            </Stack>
+
+            {storeHighlights.length > 0 && (
               <Grid container spacing={2}>
                 {storeHighlights.map((metric) => (
                   <Grid key={metric.label} item xs={12} sm={6} md={3}>
                     <Box
                       sx={(theme) => ({
-                        borderRadius: 3,
-                        p: 2,
-                        height: "100%",
-                        display: "flex",
-                        flexDirection: "column",
-                        justifyContent: "space-between",
-                        background:
-                          theme.palette.mode === "dark"
-                            ? alpha(theme.palette.primary.main, 0.12)
-                            : alpha(theme.palette.primary.main, 0.08),
-                        border: `1px solid ${alpha(theme.palette.primary.main, 0.12)}`,
+                        borderRadius: 2,
+                        border: `1px solid ${alpha(theme.palette.divider, 0.5)}`,
+                        p: 2.5,
                       })}
                     >
-                      <Typography variant="caption" sx={{ fontWeight: 600, letterSpacing: 0.4 }}>
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ textTransform: "uppercase", letterSpacing: 0.5 }}
+                      >
                         {metric.label}
                       </Typography>
                       <Typography
                         variant="h6"
-                        sx={{
-                          fontWeight: 700,
-                          color: metric.valueColor ?? "text.primary",
-                        }}
+                        sx={{ mt: 1, fontWeight: 700, color: metric.tone ?? "text.primary" }}
                       >
                         {metric.value}
                       </Typography>
-                      {metric.caption && (
-                        <Typography variant="caption" color="text.secondary">
-                          {metric.caption}
-                        </Typography>
-                      )}
                     </Box>
                   </Grid>
                 ))}
               </Grid>
-            </Box>
-          )}
+            )}
+          </Stack>
         </Paper>
 
         {error && <Alert severity="error">{error}</Alert>}

--- a/src/components/Charts/EfficiencyTrend.jsx
+++ b/src/components/Charts/EfficiencyTrend.jsx
@@ -11,7 +11,7 @@ import {
   Bar,
   Line,
 } from "recharts";
-import { Card, CardContent, Typography, Chip, Stack } from "@mui/material";
+import { Card, CardContent, Typography, Stack } from "@mui/material";
 
 const monthFormatter = (value) =>
   new Date(0, Number(value) - 1).toLocaleString("default", { month: "short" });
@@ -33,43 +33,67 @@ export default function EfficiencyTrend({ data }) {
     ChainAvgHeadcount: parseValue(item.ChainAvgHeadcount),
   }));
 
+  const hasSalesPerEmployee = enhancedData.some((item) => item.SalesPerEmployee != null);
+  const hasChainSalesPerEmployee = enhancedData.some(
+    (item) => item.ChainAvgSalesPerEmployee != null
+  );
+  const hasAvgHeadcount = enhancedData.some((item) => item.AvgHeadcount != null);
+  const hasChainAvgHeadcount = enhancedData.some((item) => item.ChainAvgHeadcount != null);
+
+  const hasLeftSeries = hasSalesPerEmployee || hasChainSalesPerEmployee;
+  const hasRightSeries = hasAvgHeadcount || hasChainAvgHeadcount;
+
+  if (!hasLeftSeries && !hasRightSeries) {
+    return null;
+  }
+
+  const year = data[0]?.Year;
+
   return (
     <Card
-      sx={{ borderRadius: 4, boxShadow: "0 18px 40px rgba(15,23,42,0.08)" }}
+      sx={{
+        borderRadius: 3,
+        boxShadow: "none",
+        border: (theme) => `1px solid ${theme.palette.divider}`,
+        backgroundColor: (theme) => theme.palette.background.paper,
+      }}
     >
       <CardContent>
         <Stack
           direction={{ xs: "column", sm: "row" }}
-          spacing={2}
           justifyContent="space-between"
-          alignItems="flex-start"
-          mb={3}
+          alignItems={{ xs: "flex-start", sm: "center" }}
+          spacing={1.5}
+          mb={2}
         >
-          <div>
-            <Typography variant="h6" gutterBottom sx={{ fontWeight: 700 }}>
-              Workforce Efficiency
-            </Typography>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            Efficiency trend
+          </Typography>
+          {year && (
             <Typography variant="body2" color="text.secondary">
-              Compare sales productivity with average headcount across the year.
+              FY {year}
             </Typography>
-          </div>
-          <Chip label="Higher is better" color="success" variant="outlined" />
+          )}
         </Stack>
         <ResponsiveContainer width="100%" height={360}>
           <ComposedChart data={enhancedData}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
             <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
-            <YAxis
-              yAxisId="left"
-              stroke="#0ea5e9"
-              tickFormatter={(value) => `$${value.toFixed(0)}`}
-            />
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              stroke="#22c55e"
-              tickFormatter={(value) => value.toFixed(0)}
-            />
+            {hasLeftSeries && (
+              <YAxis
+                yAxisId="left"
+                stroke="#0ea5e9"
+                tickFormatter={(value) => `$${value.toFixed(0)}`}
+              />
+            )}
+            {hasRightSeries && (
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                stroke="#22c55e"
+                tickFormatter={(value) => value.toFixed(0)}
+              />
+            )}
             <Tooltip
               labelFormatter={(label) => monthFormatter(label)}
               formatter={(value, name) => {
@@ -92,44 +116,52 @@ export default function EfficiencyTrend({ data }) {
               }}
             />
             <Legend />
-            <Area
-              yAxisId="left"
-              type="monotone"
-              dataKey="SalesPerEmployee"
-              name="Store Sales per Employee"
-              stroke="#0ea5e9"
-              fill="#0ea5e933"
-              strokeWidth={3}
-              activeDot={{ r: 6 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="ChainAvgSalesPerEmployee"
-              name="Chain Avg Sales per Employee"
-              stroke="#38bdf8"
-              strokeWidth={3}
-              strokeDasharray="5 5"
-              dot={false}
-            />
-            <Bar
-              yAxisId="right"
-              dataKey="AvgHeadcount"
-              name="Store Avg Headcount"
-              fill="#22c55e"
-              radius={[12, 12, 0, 0]}
-              barSize={28}
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="ChainAvgHeadcount"
-              name="Chain Avg Headcount"
-              stroke="#4ade80"
-              strokeWidth={3}
-              strokeDasharray="3 6"
-              dot={false}
-            />
+            {hasSalesPerEmployee && (
+              <Area
+                yAxisId="left"
+                type="monotone"
+                dataKey="SalesPerEmployee"
+                name="Store Sales per Employee"
+                stroke="#0ea5e9"
+                fill="#0ea5e933"
+                strokeWidth={3}
+                activeDot={{ r: 6 }}
+              />
+            )}
+            {hasChainSalesPerEmployee && (
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="ChainAvgSalesPerEmployee"
+                name="Chain Avg Sales per Employee"
+                stroke="#38bdf8"
+                strokeWidth={3}
+                strokeDasharray="5 5"
+                dot={false}
+              />
+            )}
+            {hasAvgHeadcount && (
+              <Bar
+                yAxisId="right"
+                dataKey="AvgHeadcount"
+                name="Store Avg Headcount"
+                fill="#22c55e"
+                radius={[12, 12, 0, 0]}
+                barSize={28}
+              />
+            )}
+            {hasChainAvgHeadcount && (
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="ChainAvgHeadcount"
+                name="Chain Avg Headcount"
+                stroke="#4ade80"
+                strokeWidth={3}
+                strokeDasharray="3 6"
+                dot={false}
+              />
+            )}
           </ComposedChart>
         </ResponsiveContainer>
       </CardContent>

--- a/src/components/Charts/PeopleHealth.jsx
+++ b/src/components/Charts/PeopleHealth.jsx
@@ -31,32 +31,65 @@ export default function PeopleHealth({ data }) {
     ChainAvgTurnover: parseValue(item.ChainAvgTurnover),
   }));
 
+  const hasHeadcountGrowth = normalizedData.some((item) => item.HeadcountGrowthPct != null);
+  const hasChainGrowth = normalizedData.some((item) => item.ChainAvgGrowth != null);
+  const hasTurnover = normalizedData.some((item) => item.Turnover != null);
+  const hasChainTurnover = normalizedData.some((item) => item.ChainAvgTurnover != null);
+
+  const hasLeftSeries = hasHeadcountGrowth || hasChainGrowth;
+  const hasRightSeries = hasTurnover || hasChainTurnover;
+
+  if (!hasLeftSeries && !hasRightSeries) {
+    return null;
+  }
+
+  const year = data[0]?.Year;
+
   return (
-    <Card sx={{ borderRadius: 4, boxShadow: "0 18px 40px rgba(15,23,42,0.08)" }}>
+    <Card
+      sx={{
+        borderRadius: 3,
+        boxShadow: "none",
+        border: (theme) => `1px solid ${theme.palette.divider}`,
+        backgroundColor: (theme) => theme.palette.background.paper,
+      }}
+    >
       <CardContent>
-        <Stack spacing={1} mb={3}>
+        <Stack
+          direction={{ xs: "column", sm: "row" }}
+          justifyContent="space-between"
+          alignItems={{ xs: "flex-start", sm: "center" }}
+          spacing={1.5}
+          mb={2}
+        >
           <Typography variant="h6" sx={{ fontWeight: 700 }}>
-            People Health
+            People health
           </Typography>
-          <Typography variant="body2" color="text.secondary">
-            Monitor headcount growth and turnover to stay ahead of retention risks.
-          </Typography>
+          {year && (
+            <Typography variant="body2" color="text.secondary">
+              FY {year}
+            </Typography>
+          )}
         </Stack>
         <ResponsiveContainer width="100%" height={320}>
           <LineChart data={normalizedData}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
             <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
-            <YAxis
-              yAxisId="left"
-              stroke="#8b5cf6"
-              tickFormatter={(value) => `${value.toFixed(1)}%`}
-            />
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              stroke="#f97316"
-              tickFormatter={(value) => `${value.toFixed(1)}%`}
-            />
+            {hasLeftSeries && (
+              <YAxis
+                yAxisId="left"
+                stroke="#8b5cf6"
+                tickFormatter={(value) => `${value.toFixed(1)}%`}
+              />
+            )}
+            {hasRightSeries && (
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                stroke="#f97316"
+                tickFormatter={(value) => `${value.toFixed(1)}%`}
+              />
+            )}
             <Tooltip
               labelFormatter={(label) => monthFormatter(label)}
               formatter={(value, name) => {
@@ -73,47 +106,55 @@ export default function PeopleHealth({ data }) {
                   default:
                     return [formattedValue, name];
                 }
-              }}
+            }}
             />
             <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="HeadcountGrowthPct"
-              name="Store Headcount Growth"
-              stroke="#8b5cf6"
-              strokeWidth={3}
-              dot={{ r: 3 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="ChainAvgGrowth"
-              name="Chain Avg Headcount Growth"
-              stroke="#c084fc"
-              strokeWidth={3}
-              strokeDasharray="5 5"
-              dot={false}
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="Turnover"
-              name="Store Turnover"
-              stroke="#f97316"
-              strokeWidth={3}
-              dot={{ r: 3 }}
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="ChainAvgTurnover"
-              name="Chain Avg Turnover"
-              stroke="#fbbf24"
-              strokeWidth={3}
-              strokeDasharray="3 6"
-              dot={false}
-            />
+            {hasHeadcountGrowth && (
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="HeadcountGrowthPct"
+                name="Store Headcount Growth"
+                stroke="#8b5cf6"
+                strokeWidth={3}
+                dot={{ r: 3 }}
+              />
+            )}
+            {hasChainGrowth && (
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="ChainAvgGrowth"
+                name="Chain Avg Headcount Growth"
+                stroke="#c084fc"
+                strokeWidth={3}
+                strokeDasharray="5 5"
+                dot={false}
+              />
+            )}
+            {hasTurnover && (
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="Turnover"
+                name="Store Turnover"
+                stroke="#f97316"
+                strokeWidth={3}
+                dot={{ r: 3 }}
+              />
+            )}
+            {hasChainTurnover && (
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="ChainAvgTurnover"
+                name="Chain Avg Turnover"
+                stroke="#fbbf24"
+                strokeWidth={3}
+                strokeDasharray="3 6"
+                dot={false}
+              />
+            )}
           </LineChart>
         </ResponsiveContainer>
       </CardContent>

--- a/src/components/Charts/SalesTrend.jsx
+++ b/src/components/Charts/SalesTrend.jsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
   Legend,
 } from "recharts";
-import { Card, CardContent, Typography, Stack, Chip } from "@mui/material";
+import { Card, CardContent, Typography, Stack } from "@mui/material";
 
 const monthFormatter = (value) =>
   new Date(0, Number(value) - 1).toLocaleString("default", { month: "short" });
@@ -47,43 +47,69 @@ export default function SalesTrend({ data, storeId }) {
     };
   });
 
+  const hasTotalSales = enrichedData.some((item) => item.TotalSales != null);
+  const hasChainSales = enrichedData.some((item) => item.ChainAvgSales != null);
+  const hasSalesPerEmployee = enrichedData.some((item) => item.SalesPerEmployee != null);
+  const hasChainSalesPerEmployee = enrichedData.some(
+    (item) => item.ChainAvgSalesPerEmployee != null
+  );
+
+  const hasLeftSeries = hasTotalSales || hasChainSales;
+  const hasRightSeries = hasSalesPerEmployee || hasChainSalesPerEmployee;
+
+  if (!hasLeftSeries && !hasRightSeries) {
+    return null;
+  }
+
   return (
-    <Card sx={{ borderRadius: 4, boxShadow: "0 18px 40px rgba(15,23,42,0.1)" }}>
+    <Card
+      sx={{
+        borderRadius: 3,
+        boxShadow: "none",
+        border: (theme) => `1px solid ${theme.palette.divider}`,
+        backgroundColor: (theme) => theme.palette.background.paper,
+      }}
+    >
       <CardContent>
         <Stack
           direction={{ xs: "column", sm: "row" }}
-          spacing={2}
           justifyContent="space-between"
-          alignItems="flex-start"
-          mb={3}
+          alignItems={{ xs: "flex-start", sm: "center" }}
+          spacing={1.5}
+          mb={2}
         >
-          <div>
-            <Typography variant="h6" gutterBottom sx={{ fontWeight: 700 }}>
-              Revenue & Efficiency Trend
-            </Typography>
+          <Typography variant="h6" sx={{ fontWeight: 700 }}>
+            Revenue trend
+          </Typography>
+          {(storeId || year) && (
             <Typography variant="body2" color="text.secondary">
-              Tracking monthly performance for store {storeId} in {year}.
+              {[storeId && `Store ${storeId}`, year && `FY ${year}`]
+                .filter(Boolean)
+                .join(" · ")}
             </Typography>
-          </div>
-          <Chip label="Store vs. chain benchmarks" color="primary" variant="outlined" />
+          )}
         </Stack>
         <ResponsiveContainer width="100%" height={380}>
           <LineChart data={enrichedData}>
             <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
             <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
-            <YAxis
-              yAxisId="left"
-              tickFormatter={(value) =>
-                value >= 1000 ? `${(value / 1000).toFixed(0)}k` : value
-              }
-              stroke="#2563eb"
-            />
-            <YAxis
-              yAxisId="right"
-              orientation="right"
-              tickFormatter={(value) => `$${value.toFixed(0)}`}
-              stroke="#f59e0b"
-            />
+            {hasLeftSeries && (
+              <YAxis
+                yAxisId="left"
+                tickFormatter={(value) =>
+                  value >= 1000 ? `${(value / 1000).toFixed(0)}k` : value
+                }
+                stroke="#2563eb"
+              />
+            )}
+            {hasRightSeries && (
+              <YAxis
+                yAxisId="right"
+                orientation="right"
+                tickFormatter={(value) => `$${value.toFixed(0)}`}
+                stroke="#f59e0b"
+              />
+            )}
             <Tooltip
               formatter={(val, name) => {
                 if (name === "TotalSales") return [currencyFormatter(val), "Total Sales"];
@@ -104,46 +130,54 @@ export default function SalesTrend({ data, storeId }) {
               labelFormatter={(label) => monthFormatter(label)}
             />
             <Legend />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="TotalSales"
-              name="Store Total Sales"
-              stroke="#2563eb"
-              strokeWidth={3}
-              dot={{ r: 3 }}
-              activeDot={{ r: 6 }}
-            />
-            <Line
-              yAxisId="left"
-              type="monotone"
-              dataKey="ChainAvgSales"
-              name="Chain Avg Sales"
-              stroke="#60a5fa"
-              strokeWidth={3}
-              strokeDasharray="6 6"
-              dot={false}
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="SalesPerEmployee"
-              name="Store Sales per Employee"
-              stroke="#f59e0b"
-              strokeWidth={3}
-              dot={{ r: 3 }}
-              activeDot={{ r: 6 }}
-            />
-            <Line
-              yAxisId="right"
-              type="monotone"
-              dataKey="ChainAvgSalesPerEmployee"
-              name="Chain Avg Sales per Employee"
-              stroke="#facc15"
-              strokeWidth={3}
-              strokeDasharray="4 4"
-              dot={false}
-            />
+            {hasTotalSales && (
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="TotalSales"
+                name="Store Total Sales"
+                stroke="#2563eb"
+                strokeWidth={3}
+                dot={{ r: 3 }}
+                activeDot={{ r: 6 }}
+              />
+            )}
+            {hasChainSales && (
+              <Line
+                yAxisId="left"
+                type="monotone"
+                dataKey="ChainAvgSales"
+                name="Chain Avg Sales"
+                stroke="#60a5fa"
+                strokeWidth={3}
+                strokeDasharray="6 6"
+                dot={false}
+              />
+            )}
+            {hasSalesPerEmployee && (
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="SalesPerEmployee"
+                name="Store Sales per Employee"
+                stroke="#f59e0b"
+                strokeWidth={3}
+                dot={{ r: 3 }}
+                activeDot={{ r: 6 }}
+              />
+            )}
+            {hasChainSalesPerEmployee && (
+              <Line
+                yAxisId="right"
+                type="monotone"
+                dataKey="ChainAvgSalesPerEmployee"
+                name="Chain Avg Sales per Employee"
+                stroke="#facc15"
+                strokeWidth={3}
+                strokeDasharray="4 4"
+                dot={false}
+              />
+            )}
           </LineChart>
         </ResponsiveContainer>
       </CardContent>

--- a/src/components/KpiCard.jsx
+++ b/src/components/KpiCard.jsx
@@ -1,75 +1,41 @@
 import React from "react";
-import { Card, CardContent, Typography, Box, Chip, Stack } from "@mui/material";
-import TrendingUpIcon from "@mui/icons-material/TrendingUp";
-import TrendingDownIcon from "@mui/icons-material/TrendingDown";
+import { Card, CardContent, Typography } from "@mui/material";
 
-export default function KpiCard({ title, value, change, secondary = [] }) {
+export default function KpiCard({ title, value, change }) {
   const showChange = Number.isFinite(change);
-  const positive = showChange && change >= 0;
 
-  const renderSecondaryChip = (chip) => {
-    if (!chip || !Number.isFinite(chip.value)) return null;
-    const isPositive = chip.value >= 0;
-    return (
-      <Chip
-        key={chip.label}
-        size="small"
-        variant="outlined"
-        color={isPositive ? "success" : "error"}
-        label={`${isPositive ? "+" : ""}${chip.value.toFixed(1)}% ${chip.label}`}
-        sx={{ fontWeight: 600 }}
-      />
-    );
-  };
   return (
     <Card
       sx={{
-        borderRadius: 4,
-        boxShadow: "0 20px 45px rgba(15, 23, 42, 0.12)",
-        background: (theme) => theme.palette.background.paper,
-        color: (theme) => theme.palette.text.primary,
+        borderRadius: 3,
+        boxShadow: "none",
         border: (theme) => `1px solid ${theme.palette.divider}`,
+        backgroundColor: (theme) => theme.palette.background.paper,
       }}
     >
       <CardContent>
-        <Typography variant="subtitle2" sx={{ opacity: 0.7 }}>
+        <Typography
+          variant="caption"
+          color="text.secondary"
+          sx={{ textTransform: "uppercase", letterSpacing: 0.5 }}
+        >
           {title}
         </Typography>
-        <Typography variant="h4" sx={{ fontWeight: 700, mt: 1 }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, mt: 1 }}>
           {value}
         </Typography>
-        <Stack
-          direction="row"
-          flexWrap="wrap"
-          spacing={1}
-          useFlexGap
-          sx={{ mt: 2 }}
-          alignItems="center"
-        >
-          {showChange ? (
-            <Box display="flex" alignItems="center" gap={1}>
-              {positive ? (
-                <TrendingUpIcon sx={{ color: "#16a34a" }} />
-              ) : (
-                <TrendingDownIcon sx={{ color: "#dc2626" }} />
-              )}
-              <Chip
-                size="small"
-                color={positive ? "success" : "error"}
-                label={`${positive ? "+" : ""}${change.toFixed(1)}% vs prev.`}
-                sx={{ fontWeight: 600 }}
-              />
-            </Box>
-          ) : (
-            <Chip
-              size="small"
-              label="No previous month"
-              sx={{ fontWeight: 600, color: "text.secondary" }}
-              variant="outlined"
-            />
-          )}
-          {secondary.map((chip) => renderSecondaryChip(chip))}
-        </Stack>
+        {showChange && (
+          <Typography
+            variant="body2"
+            sx={{
+              mt: 1,
+              fontWeight: 600,
+              color: change >= 0 ? "success.main" : "error.main",
+            }}
+          >
+            {`${change >= 0 ? "+" : ""}${change.toFixed(1)}% vs previous`}
+          </Typography>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/KpiOverview.jsx
+++ b/src/components/KpiOverview.jsx
@@ -51,74 +51,47 @@ export default function KpiOverview({ data }) {
 
   const totalSales = toNumber(latest.TotalSales);
   const prevSales = previous ? toNumber(previous.TotalSales) : null;
-  const chainAvgSales = toNumber(latest.ChainAvgSales);
-  const prevYearSales = toNumber(latest.PrevYearTotalSales);
-
   const avgHeadcount = toNumber(latest.AvgHeadcount);
   const prevHeadcount = previous ? toNumber(previous.AvgHeadcount) : null;
-  const chainAvgHeadcount = toNumber(latest.ChainAvgHeadcount);
 
   const salesPerEmp = toNumber(latest.SalesPerEmployee);
   const prevSalesPerEmp = previous ? toNumber(previous.SalesPerEmployee) : null;
-  const chainAvgSalesPerEmp = toNumber(latest.ChainAvgSalesPerEmployee);
-  const prevYearSalesPerEmp = toNumber(latest.PrevYearSalesPerEmployee);
 
   const turnover = toNumber(latest.Turnover);
   const prevTurnover = previous ? toNumber(previous.Turnover) : null;
-  const chainAvgTurnover = toNumber(latest.ChainAvgTurnover);
-  const prevYearTurnover = toNumber(latest.PrevYearTurnover);
 
   const cards = [
-    {
-      title: "Total Sales",
-      value: totalSales != null ? formatCurrency(totalSales) : "-",
-      change: calculateChange(totalSales, prevSales),
-      secondary: [
-        prevYearSales != null
-          ? { label: "vs last year", value: calculateChange(totalSales, prevYearSales) }
-          : null,
-        chainAvgSales != null
-          ? { label: "vs chain avg", value: calculateChange(totalSales, chainAvgSales) }
-          : null,
-      ].filter(Boolean),
+    totalSales != null && {
+      title: "Total sales",
+      value: formatCurrency(totalSales),
+      change: prevSales != null ? calculateChange(totalSales, prevSales) : null,
     },
-    {
-      title: "Avg Headcount",
-      value: avgHeadcount != null ? avgHeadcount.toFixed(1) : "-",
-      change: calculateChange(avgHeadcount, prevHeadcount),
-      secondary: [
-        chainAvgHeadcount != null
-          ? { label: "vs chain avg", value: calculateChange(avgHeadcount, chainAvgHeadcount) }
-          : null,
-      ].filter(Boolean),
+    avgHeadcount != null && {
+      title: "Avg headcount",
+      value: avgHeadcount.toFixed(1),
+      change: prevHeadcount != null ? calculateChange(avgHeadcount, prevHeadcount) : null,
     },
-    {
-      title: "Sales per Employee",
-      value: salesPerEmp != null ? `$${salesPerEmp.toFixed(2)}` : "-",
-      change: calculateChange(salesPerEmp, prevSalesPerEmp),
-      secondary: [
-        prevYearSalesPerEmp != null
-          ? { label: "vs last year", value: calculateChange(salesPerEmp, prevYearSalesPerEmp) }
-          : null,
-        chainAvgSalesPerEmp != null
-          ? { label: "vs chain avg", value: calculateChange(salesPerEmp, chainAvgSalesPerEmp) }
-          : null,
-      ].filter(Boolean),
+    salesPerEmp != null && {
+      title: "Sales per employee",
+      value: `$${salesPerEmp.toFixed(0)}`,
+      change: prevSalesPerEmp != null ? calculateChange(salesPerEmp, prevSalesPerEmp) : null,
     },
-    {
+    turnover != null && {
       title: "Turnover",
-      value: turnover != null ? turnover.toFixed(1) + "%" : "-",
-      change: calculateChange(turnover, prevTurnover),
-      secondary: [
-        prevYearTurnover != null
-          ? { label: "vs last year", value: calculateChange(turnover, prevYearTurnover) }
-          : null,
-        chainAvgTurnover != null
-          ? { label: "vs chain avg", value: calculateChange(turnover, chainAvgTurnover) }
-          : null,
-      ].filter(Boolean),
+      value: `${turnover.toFixed(1)}%`,
+      change: prevTurnover != null ? calculateChange(turnover, prevTurnover) : null,
     },
-  ];
+  ].filter(Boolean);
+
+  if (cards.length === 0) {
+    return (
+      <Box sx={{ textAlign: "center", py: 6 }}>
+        <Typography variant="body1" color="text.secondary">
+          No KPI values available yet.
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
     <Grid container spacing={3}>


### PR DESCRIPTION
## Summary
- streamline the KPI snapshot header so it only surfaces available store metrics alongside compact filters
- render KPI cards and trend charts only for populated values while simplifying their presentation
- trim chart headers and conditionally draw axes/series to avoid empty visuals when data is missing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3acb5eec883248c6063cda3a98d68