### PR TITLE
Enhance dashboard chart presentation

### DIFF
--- a/src/components/Charts/EfficiencyTrend.jsx
+++ b/src/components/Charts/EfficiencyTrend.jsx
@@ -11,7 +11,7 @@ import {
   Bar,
   Line,
 } from "recharts";
-import { Card, CardContent, Typography, Stack } from "@mui/material";
+import { Card, CardContent, Typography, Stack, Divider } from "@mui/material";
 
 const monthFormatter = (value) =>
   new Date(0, Number(value) - 1).toLocaleString("default", { month: "short" });
@@ -52,46 +52,79 @@ export default function EfficiencyTrend({ data }) {
   return (
     <Card
       sx={{
-        borderRadius: 3,
-        boxShadow: "none",
-        border: (theme) => `1px solid ${theme.palette.divider}`,
-        backgroundColor: (theme) => theme.palette.background.paper,
+        borderRadius: 4,
+        boxShadow: "0 10px 36px rgba(15, 23, 42, 0.09)",
+        border: "none",
+        background: (theme) =>
+          theme.palette.mode === "dark"
+            ? `linear-gradient(140deg, ${theme.palette.grey[900]}, ${theme.palette.grey[800]})`
+            : "linear-gradient(140deg, #ecfdf5, #f0fdf4)",
       }}
     >
-      <CardContent>
-        <Stack
-          direction={{ xs: "column", sm: "row" }}
-          justifyContent="space-between"
-          alignItems={{ xs: "flex-start", sm: "center" }}
-          spacing={1.5}
-          mb={2}
-        >
-          <Typography variant="h6" sx={{ fontWeight: 700 }}>
-            Efficiency trend
-          </Typography>
-          {year && (
-            <Typography variant="body2" color="text.secondary">
-              FY {year}
+      <CardContent sx={{ px: { xs: 3, md: 4 }, py: { xs: 3, md: 4 } }}>
+        <Stack spacing={2.5} mb={3}>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            justifyContent="space-between"
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            spacing={1.5}
+          >
+            <Typography variant="h6" sx={{ fontWeight: 800, letterSpacing: 0.3 }}>
+              Efficiency trend
             </Typography>
-          )}
+            {year && (
+              <Typography variant="body2" color="text.secondary">
+                FY {year}
+              </Typography>
+            )}
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            Visualize productivity alongside staffing changes to spot months where
+            efficiency gains or losses align with headcount shifts.
+          </Typography>
         </Stack>
-        <ResponsiveContainer width="100%" height={360}>
-          <ComposedChart data={enhancedData}>
-            <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
-            <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
+        <Divider sx={{ opacity: 0.2, mb: 3 }} />
+        <ResponsiveContainer width="100%" height={400}>
+          <ComposedChart
+            data={enhancedData}
+            margin={{ top: 10, right: 24, left: 8, bottom: 0 }}
+          >
+            <defs>
+              <linearGradient id="salesPerEmployeeGradient" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="#0ea5e9" stopOpacity={0.35} />
+                <stop offset="95%" stopColor="#0ea5e9" stopOpacity={0.05} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="4 8" stroke="rgba(15, 23, 42, 0.08)" />
+            <XAxis
+              dataKey="MonthNumber"
+              tickFormatter={monthFormatter}
+              tickLine={false}
+              axisLine={false}
+            />
             {hasLeftSeries && (
               <YAxis
                 yAxisId="left"
-                stroke="#0ea5e9"
+                stroke="#0284c7"
                 tickFormatter={(value) => `$${value.toFixed(0)}`}
+                axisLine={false}
+                tickLine={false}
+                label={{
+                  value: "Sales per employee",
+                  angle: -90,
+                  position: "insideLeft",
+                }}
               />
             )}
             {hasRightSeries && (
               <YAxis
                 yAxisId="right"
                 orientation="right"
-                stroke="#22c55e"
+                stroke="#16a34a"
                 tickFormatter={(value) => value.toFixed(0)}
+                axisLine={false}
+                tickLine={false}
+                label={{ value: "Headcount", angle: 90, position: "insideRight" }}
               />
             )}
             <Tooltip
@@ -114,18 +147,23 @@ export default function EfficiencyTrend({ data }) {
                 }
                 return [value, name];
               }}
+              contentStyle={{
+                borderRadius: 12,
+                border: "1px solid rgba(148, 163, 184, 0.35)",
+                boxShadow: "0 8px 20px rgba(15, 23, 42, 0.1)",
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ paddingTop: 12 }} iconType="circle" />
             {hasSalesPerEmployee && (
               <Area
                 yAxisId="left"
                 type="monotone"
                 dataKey="SalesPerEmployee"
-                name="Store Sales per Employee"
-                stroke="#0ea5e9"
-                fill="#0ea5e933"
+                name="Store sales per employee"
+                stroke="#0284c7"
+                fill="url(#salesPerEmployeeGradient)"
                 strokeWidth={3}
-                activeDot={{ r: 6 }}
+                activeDot={{ r: 7 }}
               />
             )}
             {hasChainSalesPerEmployee && (
@@ -133,10 +171,10 @@ export default function EfficiencyTrend({ data }) {
                 yAxisId="left"
                 type="monotone"
                 dataKey="ChainAvgSalesPerEmployee"
-                name="Chain Avg Sales per Employee"
+                name="Chain avg sales per employee"
                 stroke="#38bdf8"
                 strokeWidth={3}
-                strokeDasharray="5 5"
+                strokeDasharray="10 6"
                 dot={false}
               />
             )}
@@ -144,10 +182,10 @@ export default function EfficiencyTrend({ data }) {
               <Bar
                 yAxisId="right"
                 dataKey="AvgHeadcount"
-                name="Store Avg Headcount"
+                name="Store avg headcount"
                 fill="#22c55e"
-                radius={[12, 12, 0, 0]}
-                barSize={28}
+                radius={[16, 16, 0, 0]}
+                barSize={32}
               />
             )}
             {hasChainAvgHeadcount && (
@@ -155,10 +193,10 @@ export default function EfficiencyTrend({ data }) {
                 yAxisId="right"
                 type="monotone"
                 dataKey="ChainAvgHeadcount"
-                name="Chain Avg Headcount"
+                name="Chain avg headcount"
                 stroke="#4ade80"
                 strokeWidth={3}
-                strokeDasharray="3 6"
+                strokeDasharray="6 6"
                 dot={false}
               />
             )}

--- a/src/components/Charts/PeopleHealth.jsx
+++ b/src/components/Charts/PeopleHealth.jsx
@@ -9,7 +9,7 @@ import {
   Legend,
   Line,
 } from "recharts";
-import { Card, CardContent, Typography, Stack } from "@mui/material";
+import { Card, CardContent, Typography, Stack, Divider } from "@mui/material";
 
 const monthFormatter = (value) =>
   new Date(0, Number(value) - 1).toLocaleString("default", { month: "short" });
@@ -48,38 +48,58 @@ export default function PeopleHealth({ data }) {
   return (
     <Card
       sx={{
-        borderRadius: 3,
-        boxShadow: "none",
-        border: (theme) => `1px solid ${theme.palette.divider}`,
-        backgroundColor: (theme) => theme.palette.background.paper,
+        borderRadius: 4,
+        boxShadow: "0 10px 36px rgba(15, 23, 42, 0.08)",
+        border: "none",
+        background: (theme) =>
+          theme.palette.mode === "dark"
+            ? `linear-gradient(135deg, ${theme.palette.grey[900]}, ${theme.palette.grey[800]})`
+            : "linear-gradient(135deg, #fdf2f8, #fce7f3)",
       }}
     >
-      <CardContent>
-        <Stack
-          direction={{ xs: "column", sm: "row" }}
-          justifyContent="space-between"
-          alignItems={{ xs: "flex-start", sm: "center" }}
-          spacing={1.5}
-          mb={2}
-        >
-          <Typography variant="h6" sx={{ fontWeight: 700 }}>
-            People health
-          </Typography>
-          {year && (
-            <Typography variant="body2" color="text.secondary">
-              FY {year}
+      <CardContent sx={{ px: { xs: 3, md: 4 }, py: { xs: 3, md: 4 } }}>
+        <Stack spacing={2} mb={3}>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            justifyContent="space-between"
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            spacing={1.5}
+          >
+            <Typography variant="h6" sx={{ fontWeight: 800, letterSpacing: 0.3 }}>
+              People health
             </Typography>
-          )}
+            {year && (
+              <Typography variant="body2" color="text.secondary">
+                FY {year}
+              </Typography>
+            )}
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            Monitor retention and growth rates side-by-side to quickly identify
+            people risks or standout improvements.
+          </Typography>
         </Stack>
-        <ResponsiveContainer width="100%" height={360}>
-          <LineChart data={normalizedData}>
-            <CartesianGrid strokeDasharray="3 3" opacity={0.15} />
-            <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
+        <Divider sx={{ opacity: 0.2, mb: 3 }} />
+        <ResponsiveContainer width="100%" height={400}>
+          <LineChart
+            data={normalizedData}
+            margin={{ top: 10, right: 24, left: 8, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="4 8" stroke="rgba(15, 23, 42, 0.08)" />
+            <XAxis
+              dataKey="MonthNumber"
+              tickFormatter={monthFormatter}
+              tickLine={false}
+              axisLine={false}
+            />
             {hasLeftSeries && (
               <YAxis
                 yAxisId="left"
-                stroke="#8b5cf6"
+                stroke="#7c3aed"
                 tickFormatter={(value) => `${value.toFixed(1)}%`}
+                axisLine={false}
+                tickLine={false}
+                label={{ value: "Headcount growth", angle: -90, position: "insideLeft" }}
               />
             )}
             {hasRightSeries && (
@@ -88,6 +108,9 @@ export default function PeopleHealth({ data }) {
                 orientation="right"
                 stroke="#f97316"
                 tickFormatter={(value) => `${value.toFixed(1)}%`}
+                axisLine={false}
+                tickLine={false}
+                label={{ value: "Turnover", angle: 90, position: "insideRight" }}
               />
             )}
             <Tooltip
@@ -106,18 +129,24 @@ export default function PeopleHealth({ data }) {
                   default:
                     return [formattedValue, name];
                 }
-            }}
+              }}
+              contentStyle={{
+                borderRadius: 12,
+                border: "1px solid rgba(148, 163, 184, 0.35)",
+                boxShadow: "0 8px 20px rgba(15, 23, 42, 0.1)",
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ paddingTop: 12 }} iconType="circle" />
             {hasHeadcountGrowth && (
               <Line
                 yAxisId="left"
                 type="monotone"
                 dataKey="HeadcountGrowthPct"
-                name="Store Headcount Growth"
-                stroke="#8b5cf6"
-                strokeWidth={3}
-                dot={{ r: 3 }}
+                name="Store headcount growth"
+                stroke="#7c3aed"
+                strokeWidth={3.2}
+                dot={{ r: 4 }}
+                activeDot={{ r: 7 }}
               />
             )}
             {hasChainGrowth && (
@@ -125,10 +154,10 @@ export default function PeopleHealth({ data }) {
                 yAxisId="left"
                 type="monotone"
                 dataKey="ChainAvgGrowth"
-                name="Chain Avg Headcount Growth"
+                name="Chain avg headcount growth"
                 stroke="#c084fc"
                 strokeWidth={3}
-                strokeDasharray="5 5"
+                strokeDasharray="10 6"
                 dot={false}
               />
             )}
@@ -137,10 +166,11 @@ export default function PeopleHealth({ data }) {
                 yAxisId="right"
                 type="monotone"
                 dataKey="Turnover"
-                name="Store Turnover"
+                name="Store turnover"
                 stroke="#f97316"
                 strokeWidth={3}
-                dot={{ r: 3 }}
+                dot={{ r: 4 }}
+                activeDot={{ r: 7 }}
               />
             )}
             {hasChainTurnover && (
@@ -148,10 +178,10 @@ export default function PeopleHealth({ data }) {
                 yAxisId="right"
                 type="monotone"
                 dataKey="ChainAvgTurnover"
-                name="Chain Avg Turnover"
+                name="Chain avg turnover"
                 stroke="#fbbf24"
                 strokeWidth={3}
-                strokeDasharray="3 6"
+                strokeDasharray="6 6"
                 dot={false}
               />
             )}

--- a/src/components/Charts/SalesTrend.jsx
+++ b/src/components/Charts/SalesTrend.jsx
@@ -9,7 +9,7 @@ import {
   ResponsiveContainer,
   Legend,
 } from "recharts";
-import { Card, CardContent, Typography, Stack } from "@mui/material";
+import { Card, CardContent, Typography, Stack, Divider } from "@mui/material";
 
 const monthFormatter = (value) =>
   new Date(0, Number(value) - 1).toLocaleString("default", { month: "short" });
@@ -64,42 +64,62 @@ export default function SalesTrend({ data, storeId }) {
   return (
     <Card
       sx={{
-        borderRadius: 3,
-        boxShadow: "none",
-        border: (theme) => `1px solid ${theme.palette.divider}`,
-        backgroundColor: (theme) => theme.palette.background.paper,
+        borderRadius: 4,
+        boxShadow: "0 12px 40px rgba(15, 23, 42, 0.08)",
+        border: "none",
+        background: (theme) =>
+          theme.palette.mode === "dark"
+            ? `linear-gradient(135deg, ${theme.palette.grey[900]}, ${theme.palette.grey[800]})`
+            : "linear-gradient(135deg, #eff6ff, #eef2ff)",
       }}
     >
-      <CardContent>
-        <Stack
-          direction={{ xs: "column", sm: "row" }}
-          justifyContent="space-between"
-          alignItems={{ xs: "flex-start", sm: "center" }}
-          spacing={1.5}
-          mb={2}
-        >
-          <Typography variant="h6" sx={{ fontWeight: 700 }}>
-            Revenue trend
-          </Typography>
-          {(storeId || year) && (
-            <Typography variant="body2" color="text.secondary">
-              {[storeId && `Store ${storeId}`, year && `FY ${year}`]
-                .filter(Boolean)
-                .join(" · ")}
+      <CardContent sx={{ px: { xs: 3, md: 4 }, py: { xs: 3, md: 4 } }}>
+        <Stack spacing={2} mb={3}>
+          <Stack
+            direction={{ xs: "column", sm: "row" }}
+            justifyContent="space-between"
+            alignItems={{ xs: "flex-start", sm: "center" }}
+            spacing={1.5}
+          >
+            <Typography variant="h6" sx={{ fontWeight: 800, letterSpacing: 0.3 }}>
+              Revenue trend
             </Typography>
-          )}
+            {(storeId || year) && (
+              <Typography variant="body2" color="text.secondary">
+                {[storeId && `Store ${storeId}`, year && `FY ${year}`]
+                  .filter(Boolean)
+                  .join(" · ")}
+              </Typography>
+            )}
+          </Stack>
+          <Typography variant="body2" color="text.secondary">
+            Track how your store compares to the chain average across revenue and
+            productivity metrics each month.
+          </Typography>
         </Stack>
-        <ResponsiveContainer width="100%" height={380}>
-          <LineChart data={enrichedData}>
-            <CartesianGrid strokeDasharray="3 3" opacity={0.2} />
-            <XAxis dataKey="MonthNumber" tickFormatter={monthFormatter} />
+        <Divider sx={{ opacity: 0.25, mb: 3 }} />
+        <ResponsiveContainer width="100%" height={440}>
+          <LineChart
+            data={enrichedData}
+            margin={{ top: 10, right: 24, left: 8, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="4 8" stroke="rgba(15, 23, 42, 0.08)" />
+            <XAxis
+              dataKey="MonthNumber"
+              tickFormatter={monthFormatter}
+              tickLine={false}
+              axisLine={false}
+            />
             {hasLeftSeries && (
               <YAxis
                 yAxisId="left"
                 tickFormatter={(value) =>
                   value >= 1000 ? `${(value / 1000).toFixed(0)}k` : value
                 }
-                stroke="#2563eb"
+                stroke="#1d4ed8"
+                axisLine={false}
+                tickLine={false}
+                label={{ value: "Revenue", angle: -90, position: "insideLeft" }}
               />
             )}
             {hasRightSeries && (
@@ -107,7 +127,14 @@ export default function SalesTrend({ data, storeId }) {
                 yAxisId="right"
                 orientation="right"
                 tickFormatter={(value) => `$${value.toFixed(0)}`}
-                stroke="#f59e0b"
+                stroke="#ea580c"
+                axisLine={false}
+                tickLine={false}
+                label={{
+                  value: "Sales per employee",
+                  angle: 90,
+                  position: "insideRight",
+                }}
               />
             )}
             <Tooltip
@@ -128,18 +155,23 @@ export default function SalesTrend({ data, storeId }) {
                 return [val, name];
               }}
               labelFormatter={(label) => monthFormatter(label)}
+              contentStyle={{
+                borderRadius: 12,
+                border: "1px solid rgba(148, 163, 184, 0.35)",
+                boxShadow: "0 8px 20px rgba(15, 23, 42, 0.1)",
+              }}
             />
-            <Legend />
+            <Legend wrapperStyle={{ paddingTop: 12 }} iconType="circle" />
             {hasTotalSales && (
               <Line
                 yAxisId="left"
                 type="monotone"
                 dataKey="TotalSales"
-                name="Store Total Sales"
-                stroke="#2563eb"
-                strokeWidth={3}
-                dot={{ r: 3 }}
-                activeDot={{ r: 6 }}
+                name="Store total sales"
+                stroke="#1d4ed8"
+                strokeWidth={3.2}
+                dot={{ r: 4 }}
+                activeDot={{ r: 7 }}
               />
             )}
             {hasChainSales && (
@@ -147,10 +179,10 @@ export default function SalesTrend({ data, storeId }) {
                 yAxisId="left"
                 type="monotone"
                 dataKey="ChainAvgSales"
-                name="Chain Avg Sales"
+                name="Chain avg sales"
                 stroke="#60a5fa"
                 strokeWidth={3}
-                strokeDasharray="6 6"
+                strokeDasharray="10 6"
                 dot={false}
               />
             )}
@@ -159,11 +191,11 @@ export default function SalesTrend({ data, storeId }) {
                 yAxisId="right"
                 type="monotone"
                 dataKey="SalesPerEmployee"
-                name="Store Sales per Employee"
-                stroke="#f59e0b"
+                name="Store sales per employee"
+                stroke="#ea580c"
                 strokeWidth={3}
-                dot={{ r: 3 }}
-                activeDot={{ r: 6 }}
+                dot={{ r: 4 }}
+                activeDot={{ r: 7 }}
               />
             )}
             {hasChainSalesPerEmployee && (
@@ -171,10 +203,10 @@ export default function SalesTrend({ data, storeId }) {
                 yAxisId="right"
                 type="monotone"
                 dataKey="ChainAvgSalesPerEmployee"
-                name="Chain Avg Sales per Employee"
-                stroke="#facc15"
+                name="Chain avg sales per employee"
+                stroke="#fb923c"
                 strokeWidth={3}
-                strokeDasharray="4 4"
+                strokeDasharray="6 6"
                 dot={false}
               />
             )}


### PR DESCRIPTION
## Summary
- restyle sales, efficiency, and people charts with bolder cards, descriptive copy, and improved spacing for clarity
- enlarge chart canvases, refine axis styling, and add contextual labels to make comparisons easier
- upgrade tooltips and legends for a cleaner, more informative presentation across all dashboards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3c2359a0c8324a92a498e0d94de85